### PR TITLE
Verify and set default error message when ws.ErrorEvent is undefined

### DIFF
--- a/src/WSClient.ts
+++ b/src/WSClient.ts
@@ -138,6 +138,6 @@ export class WSClient extends Client
     }
 
     private error = (error: ws.ErrorEvent) => {
-        this.socketError(Buffer.from(error.message));
+        this.socketError(Buffer.from(error.message ? error.message : "Unknown error message"));
     };
 }

--- a/test/WSClient.spec.ts
+++ b/test/WSClient.spec.ts
@@ -245,4 +245,44 @@ export class WSClientError {
             assert(flag == true);
         });
     }
+
+    @Test()
+    public onerror_missing_error_message_succeeds() {
+        assert.doesNotThrow(() => {
+            const client = new WSClient({
+                "host": "host.com",
+                "port": 99,
+                "secure": false,
+            });
+            let flag = false;
+            //@ts-ignore: protected method
+            client.socketError = function(buffer: Buffer) {
+                assert(buffer.toString() == "Unknown error message");
+                flag = true;
+            };
+            //@ts-ignore: ignore missing input check
+            client.error(new Error());
+            //@ts-ignore: flag changes inside custom callback
+            assert(flag == true);
+        });
+    }
+
+    public onerror_undefined_error_succeeds() {
+        assert.doesNotThrow(() => {
+            const client = new WSClient({
+                "host": "host.com",
+                "port": 99,
+                "secure": false,
+            });
+            let flag = false;
+            //@ts-ignore: protected method
+            client.socketError = function(buffer: Buffer) {
+                flag = true;
+            };
+            //@ts-ignore: ignore missing input check
+            client.error();
+            //@ts-ignore: flag changes inside custom callback
+            assert(flag == true);
+        });
+    }
 }


### PR DESCRIPTION
This aims to handle the uncaught `TypeError` in browser or other environments in which the generic error object never defines the message property.

See also #2