### PR TITLE
Ensure WSClient IPv6 host gets surrounded with brackets and add tests

### DIFF
--- a/src/WSClient.ts
+++ b/src/WSClient.ts
@@ -59,7 +59,22 @@ export class WSClient extends Client
             throw "clientOptions is required to create socket.";
         }
 
-        const host = this.clientOptions.host ? this.clientOptions.host : "localhost";
+        let host = this.clientOptions.host ? this.clientOptions.host : "localhost";
+
+        //
+        // The following browser-friendly Node.js net module isIPv6 procedure was inspired by the net-browserify package.
+        //
+        // References:
+        // - https://www.npmjs.com/package/net-browserify
+        // - https://github.com/emersion/net-browserify
+        const isIPv6 = function(input: string) {
+            return /^(([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))$/.test(input);
+        };
+        // Ensure IPv6 host gets surrounded with brackets for later address formation
+        if(isIPv6(host)) {
+            host = `[${host}]`;
+        }
+
         const USE_TLS = this.clientOptions.secure ? true: false;
 
         let address;

--- a/test/connection.spec.ts
+++ b/test/connection.spec.ts
@@ -48,6 +48,126 @@ export class Connection {
     }
 
     @Test()
+    public async clientserver_ipv4() {
+        await new Promise(resolve => {
+            const serverOptions = {
+                host: "127.0.0.1",
+                port: 8181
+            };
+            const server = new WSServer(serverOptions);
+            server.listen();
+
+            server.onConnection( (client: Client) => {
+                client.onData( (data: Buffer) => {
+                    assert(data.toString() == "hello");
+                    client.sendString("received!");
+                });
+                client.onClose( () => {
+                    server.close();
+                    resolve();
+                });
+            });
+
+            const clientOptions = {
+                host: "127.0.0.1",
+                port: 8181
+            };
+            const client = new WSClient(clientOptions);
+            client.connect();
+
+            client.onConnect( () => {
+                client.onData( (data: Buffer) => {
+                    assert(data.toString() == "received!");
+                    client.close();
+                });
+                client.onClose( () => {
+                });
+                client.sendString("hello");
+            });
+        });
+    }
+
+    @Test()
+    public async clientserver_ipv6_short() {
+        await new Promise(resolve => {
+            const serverOptions = {
+                host: "::1",
+                port: 8181
+            };
+            const server = new WSServer(serverOptions);
+            server.listen();
+
+            server.onConnection( (client: Client) => {
+                client.onData( (data: Buffer) => {
+                    assert(data.toString() == "hello");
+                    client.sendString("received!");
+                });
+                client.onClose( () => {
+                    server.close();
+                    resolve();
+                });
+            });
+
+            const clientOptions = {
+                host: "::1",
+                port: 8181
+            };
+            const client = new WSClient(clientOptions);
+            client.connect();
+
+            client.onConnect( () => {
+                client.onData( (data: Buffer) => {
+                    assert(data.toString() == "received!");
+                    client.close();
+                });
+                client.onClose( () => {
+                });
+                client.sendString("hello");
+            });
+        });
+    }
+
+    @Test()
+    public async clientserver_ipv6_long() {
+        await new Promise(resolve => {
+            const serverOptions = {
+                host: "0:0:0:0:0:0:0:1",
+                port: 8181
+            };
+            const server = new WSServer(serverOptions);
+            server.listen();
+
+            server.onConnection( (client: Client) => {
+                client.onData( (data: Buffer) => {
+                    assert(data.toString() == "hello");
+                    client.sendString("received!");
+                });
+                client.onClose( () => {
+                    server.close();
+                    resolve();
+                });
+            });
+
+            const clientOptions = {
+                host: "0:0:0:0:0:0:0:1",
+                port: 8181
+            };
+            const client = new WSClient(clientOptions);
+            client.connect();
+
+            client.onConnect( () => {
+                client.onData( (data: Buffer) => {
+                    assert(data.toString() == "received!");
+                    client.close();
+                });
+                client.onClose( () => {
+                });
+                client.sendString("hello");
+            });
+        });
+    }
+
+    @Test()
     public async clientserver_missing_host() {
         await new Promise(resolve => {
             const serverOptions = {

--- a/test/connectionTCP.spec.ts
+++ b/test/connectionTCP.spec.ts
@@ -1,11 +1,11 @@
 import { TestSuite, Test } from "testyts";
-import {WSClient} from "../index";
-import {WSServer, Client} from "../index";
+import {TCPClient} from "../index";
+import {TCPServer, Client} from "../index";
 
 const assert = require("assert");
 
 @TestSuite()
-export class Connection {
+export class ConnectionTCP {
 
     @Test()
     public async clientserver() {
@@ -14,7 +14,7 @@ export class Connection {
                 host: "localhost",
                 port: 8181
             };
-            const server = new WSServer(serverOptions);
+            const server = new TCPServer(serverOptions);
             server.listen();
 
             server.onConnection( (client: Client) => {
@@ -32,7 +32,7 @@ export class Connection {
                 host: "localhost",
                 port: 8181
             };
-            const client = new WSClient(clientOptions);
+            const client = new TCPClient(clientOptions);
             client.connect();
 
             client.onConnect( () => {
@@ -54,7 +54,7 @@ export class Connection {
                 host: "127.0.0.1",
                 port: 8181
             };
-            const server = new WSServer(serverOptions);
+            const server = new TCPServer(serverOptions);
             server.listen();
 
             server.onConnection( (client: Client) => {
@@ -72,7 +72,7 @@ export class Connection {
                 host: "127.0.0.1",
                 port: 8181
             };
-            const client = new WSClient(clientOptions);
+            const client = new TCPClient(clientOptions);
             client.connect();
 
             client.onConnect( () => {
@@ -94,7 +94,7 @@ export class Connection {
                 host: "::1",
                 port: 8181
             };
-            const server = new WSServer(serverOptions);
+            const server = new TCPServer(serverOptions);
             server.listen();
 
             server.onConnection( (client: Client) => {
@@ -112,7 +112,7 @@ export class Connection {
                 host: "::1",
                 port: 8181
             };
-            const client = new WSClient(clientOptions);
+            const client = new TCPClient(clientOptions);
             client.connect();
 
             client.onConnect( () => {
@@ -134,7 +134,7 @@ export class Connection {
                 host: "0:0:0:0:0:0:0:1",
                 port: 8181
             };
-            const server = new WSServer(serverOptions);
+            const server = new TCPServer(serverOptions);
             server.listen();
 
             server.onConnection( (client: Client) => {
@@ -152,7 +152,7 @@ export class Connection {
                 host: "0:0:0:0:0:0:0:1",
                 port: 8181
             };
-            const client = new WSClient(clientOptions);
+            const client = new TCPClient(clientOptions);
             client.connect();
 
             client.onConnect( () => {
@@ -173,7 +173,7 @@ export class Connection {
             const serverOptions = {
                 port: 8182
             };
-            const server = new WSServer(serverOptions);
+            const server = new TCPServer(serverOptions);
             server.listen();
 
             server.onConnection( (client: Client) => {
@@ -187,7 +187,7 @@ export class Connection {
             const clientOptions = {
                 port: 8182
             };
-            const client = new WSClient(clientOptions);
+            const client = new TCPClient(clientOptions);
             client.connect();
 
             client.onConnect( () => {


### PR DESCRIPTION
Ensure `WSClient` _IPv6_ `host` gets surrounded with brackets during `socketConnect`

+ Add 3 new connection tests verifying different cases of _IPv4_ and _IPv6_ host strings