### PR TITLE
Add TLS connection test suites

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ For complete examples, please refer to the files under the [./example](https://g
 git clone https://github.com/bashlund/pocket-sockets.git
 cd pocket-sockets
 npm isntall
+cd ./test/cert/ && ./generate_self_signed_cert.sh && cd ../..
 npm test
 ```
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,7 +25,7 @@ export type ClientOptions = {
     secure?: boolean,
 
     /**
-     * If true (defualt) the client will reject any server certificate which is
+     * If true (default) the client will reject any server certificate which is
      * not approved by the trusted or the supplied list of CAs in the ca property.
      */
     rejectUnauthorized?: boolean,
@@ -86,7 +86,7 @@ export type ServerOptions = {
     requestCert?: boolean,
 
     /**
-     * If true (defualt) the server will reject any client certificate which is
+     * If true (default) the server will reject any client certificate which is
      * not approved by the trusted or the supplied list of CAs in the ca property.
      * This option only has effect if requestCert is set to true.
      */

--- a/test/cert/generate_self_signed_cert.sh
+++ b/test/cert/generate_self_signed_cert.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/sh
+openssl genrsa -out test.key 2048
+openssl req -new -key test.key -out test.csr
+openssl x509 -req -days 365 -in test.csr -signkey test.key -out test.cert

--- a/test/cert/generate_self_signed_cert.sh
+++ b/test/cert/generate_self_signed_cert.sh
@@ -1,4 +1,21 @@
 #!/usr/bin/sh
-openssl genrsa -out test.key 2048
-openssl req -new -key test.key -out test.csr
-openssl x509 -req -days 365 -in test.csr -signkey test.key -out test.cert
+
+SUBJECT=/C=SE/ST=Unknown/L=Stockholm/O=PocketSocketsTestCA
+
+# Root Certificate Authority
+CA="testCA"
+openssl genrsa -out "${CA}".key 2048
+openssl req -x509 -new -nodes -key "${CA}".key -sha256 -days 36500 -out "${CA}".cert -subj "${SUBJECT}"/CN="${CA}"
+openssl x509 -in "${CA}".cert -out "${CA}".pem -text
+
+# Server
+NAME="localhost"
+openssl genrsa -out "${NAME}".key 2048
+openssl req -new -out "${NAME}".csr -key "${NAME}".key -subj "${SUBJECT}"/CN="${NAME}"
+openssl x509 -req -days 36500 -in "${NAME}".csr -out "${NAME}".cert -CA "${CA}".cert -CAkey "${CA}".key -CAcreateserial
+
+# Client
+NAME="testClient"
+openssl genrsa -out "${NAME}".key 2048
+openssl req -new -key "${NAME}".key -out "${NAME}".csr -subj "${SUBJECT}"/CN="${NAME}"
+openssl x509 -req -days 36500 -in "${NAME}".csr -CA "${CA}".pem -CAkey "${CA}".key -CAcreateserial -out "${NAME}".cert

--- a/test/connectionTCPTLS.spec.ts
+++ b/test/connectionTCPTLS.spec.ts
@@ -1,0 +1,242 @@
+import { TestSuite, Test } from "testyts";
+import {TCPClient} from "../index";
+import {TCPServer, Client} from "../index";
+
+const assert = require("assert");
+const fs = require("fs");
+
+@TestSuite()
+export class ConnectionTCPTLS {
+
+    @Test()
+    public async clientserver() {
+        await new Promise(resolve => {
+            const serverOptions = {
+                host: "localhost",
+                port: 8181,
+                requestCert: true,
+                rejectUnauthorized: false,
+                cert: fs.readFileSync("./test/cert/test.cert"),
+                key: fs.readFileSync("./test/cert/test.key")
+            };
+            const server = new TCPServer(serverOptions);
+            server.listen();
+
+            server.onConnection( (client: Client) => {
+                client.onData( (data: Buffer) => {
+                    assert(data.toString() == "hello");
+                    client.sendString("received!");
+                });
+                client.onClose( () => {
+                    server.close();
+                    resolve();
+                });
+            });
+
+            const clientOptions = {
+                host: "localhost",
+                port: 8181,
+                secure: true,
+                rejectUnauthorized: false,
+                cert: fs.readFileSync("./test/cert/test.cert"),
+                key: fs.readFileSync("./test/cert/test.key")
+            };
+            const client = new TCPClient(clientOptions);
+            client.connect();
+
+            client.onConnect( () => {
+                client.onData( (data: Buffer) => {
+                    assert(data.toString() == "received!");
+                    client.close();
+                });
+                client.onClose( () => {
+                });
+                client.sendString("hello");
+            });
+        });
+    }
+
+    @Test()
+    public async clientserver_ipv4() {
+        await new Promise(resolve => {
+            const serverOptions = {
+                host: "127.0.0.1",
+                port: 8181,
+                requestCert: true,
+                rejectUnauthorized: false,
+                cert: fs.readFileSync("./test/cert/test.cert"),
+                key: fs.readFileSync("./test/cert/test.key")
+            };
+            const server = new TCPServer(serverOptions);
+            server.listen();
+
+            server.onConnection( (client: Client) => {
+                client.onData( (data: Buffer) => {
+                    assert(data.toString() == "hello");
+                    client.sendString("received!");
+                });
+                client.onClose( () => {
+                    server.close();
+                    resolve();
+                });
+            });
+
+            const clientOptions = {
+                host: "127.0.0.1",
+                port: 8181,
+                secure: true,
+                rejectUnauthorized: false,
+                cert: fs.readFileSync("./test/cert/test.cert"),
+                key: fs.readFileSync("./test/cert/test.key")
+            };
+            const client = new TCPClient(clientOptions);
+            client.connect();
+
+            client.onConnect( () => {
+                client.onData( (data: Buffer) => {
+                    assert(data.toString() == "received!");
+                    client.close();
+                });
+                client.onClose( () => {
+                });
+                client.sendString("hello");
+            });
+        });
+    }
+
+    @Test()
+    public async clientserver_ipv6_short() {
+        await new Promise(resolve => {
+            const serverOptions = {
+                host: "::1",
+                port: 8181,
+                requestCert: true,
+                rejectUnauthorized: false,
+                cert: fs.readFileSync("./test/cert/test.cert"),
+                key: fs.readFileSync("./test/cert/test.key")
+            };
+            const server = new TCPServer(serverOptions);
+            server.listen();
+
+            server.onConnection( (client: Client) => {
+                client.onData( (data: Buffer) => {
+                    assert(data.toString() == "hello");
+                    client.sendString("received!");
+                });
+                client.onClose( () => {
+                    server.close();
+                    resolve();
+                });
+            });
+
+            const clientOptions = {
+                host: "::1",
+                port: 8181,
+                secure: true,
+                rejectUnauthorized: false,
+                cert: fs.readFileSync("./test/cert/test.cert"),
+                key: fs.readFileSync("./test/cert/test.key")
+            };
+            const client = new TCPClient(clientOptions);
+            client.connect();
+
+            client.onConnect( () => {
+                client.onData( (data: Buffer) => {
+                    assert(data.toString() == "received!");
+                    client.close();
+                });
+                client.onClose( () => {
+                });
+                client.sendString("hello");
+            });
+        });
+    }
+
+    @Test()
+    public async clientserver_ipv6_long() {
+        await new Promise(resolve => {
+            const serverOptions = {
+                host: "0:0:0:0:0:0:0:1",
+                port: 8181,
+                requestCert: true,
+                rejectUnauthorized: false,
+                cert: fs.readFileSync("./test/cert/test.cert"),
+                key: fs.readFileSync("./test/cert/test.key")
+            };
+            const server = new TCPServer(serverOptions);
+            server.listen();
+
+            server.onConnection( (client: Client) => {
+                client.onData( (data: Buffer) => {
+                    assert(data.toString() == "hello");
+                    client.sendString("received!");
+                });
+                client.onClose( () => {
+                    server.close();
+                    resolve();
+                });
+            });
+
+            const clientOptions = {
+                host: "0:0:0:0:0:0:0:1",
+                port: 8181,
+                secure: true,
+                rejectUnauthorized: false,
+                cert: fs.readFileSync("./test/cert/test.cert"),
+                key: fs.readFileSync("./test/cert/test.key")
+            };
+            const client = new TCPClient(clientOptions);
+            client.connect();
+
+            client.onConnect( () => {
+                client.onData( (data: Buffer) => {
+                    assert(data.toString() == "received!");
+                    client.close();
+                });
+                client.onClose( () => {
+                });
+                client.sendString("hello");
+            });
+        });
+    }
+
+    @Test()
+    public async clientserver_missing_host() {
+        await new Promise(resolve => {
+            const serverOptions = {
+                port: 8182,
+                requestCert: true,
+                rejectUnauthorized: false,
+                cert: fs.readFileSync("./test/cert/test.cert"),
+                key: fs.readFileSync("./test/cert/test.key")
+            };
+            const server = new TCPServer(serverOptions);
+            server.listen();
+
+            server.onConnection( (client: Client) => {
+                client.onData( (data: Buffer) => {
+                    assert(data.toString() == "hello");
+                    server.close();
+                    resolve();
+                });
+            });
+
+            const clientOptions = {
+                port: 8182,
+                secure: true,
+                rejectUnauthorized: false,
+                cert: fs.readFileSync("./test/cert/test.cert"),
+                key: fs.readFileSync("./test/cert/test.key")
+            };
+            const client = new TCPClient(clientOptions);
+            client.connect();
+
+            client.onConnect( () => {
+                client.onData( (data: Buffer) => {
+                    client.close();
+                });
+                client.sendString("hello");
+            });
+        });
+    }
+}

--- a/test/connectionTCPTLS.spec.ts
+++ b/test/connectionTCPTLS.spec.ts
@@ -9,15 +9,16 @@ const fs = require("fs");
 export class ConnectionTCPTLS {
 
     @Test()
-    public async clientserver() {
+    public async clientserver_server_reject_unauthorized() {
         await new Promise(resolve => {
             const serverOptions = {
                 host: "localhost",
                 port: 8181,
                 requestCert: true,
-                rejectUnauthorized: false,
-                cert: fs.readFileSync("./test/cert/test.cert"),
-                key: fs.readFileSync("./test/cert/test.key")
+                rejectUnauthorized: true,
+                cert: fs.readFileSync("./test/cert/localhost.cert"),
+                key: fs.readFileSync("./test/cert/localhost.key"),
+                ca: fs.readFileSync("./test/cert/testCA.cert")
             };
             const server = new TCPServer(serverOptions);
             server.listen();
@@ -38,8 +39,157 @@ export class ConnectionTCPTLS {
                 port: 8181,
                 secure: true,
                 rejectUnauthorized: false,
-                cert: fs.readFileSync("./test/cert/test.cert"),
-                key: fs.readFileSync("./test/cert/test.key")
+                cert: fs.readFileSync("./test/cert/testClient.cert"),
+                key: fs.readFileSync("./test/cert/testClient.key"),
+                ca: fs.readFileSync("./test/cert/testCA.cert")
+            };
+            const client = new TCPClient(clientOptions);
+            client.connect();
+
+            client.onConnect( () => {
+                client.onData( (data: Buffer) => {
+                    assert(data.toString() == "received!");
+                    client.close();
+                });
+                client.onClose( () => {
+                });
+                client.sendString("hello");
+            });
+        });
+    }
+
+    @Test()
+    public async clientserver_client_reject_unauthorized() {
+        await new Promise(resolve => {
+            const serverOptions = {
+                host: "localhost",
+                port: 8181,
+                requestCert: true,
+                rejectUnauthorized: false,
+                cert: fs.readFileSync("./test/cert/localhost.cert"),
+                key: fs.readFileSync("./test/cert/localhost.key"),
+                ca: fs.readFileSync("./test/cert/testCA.cert")
+            };
+            const server = new TCPServer(serverOptions);
+            server.listen();
+
+            server.onConnection( (client: Client) => {
+                client.onData( (data: Buffer) => {
+                    assert(data.toString() == "hello");
+                    client.sendString("received!");
+                });
+                client.onClose( () => {
+                    server.close();
+                    resolve();
+                });
+            });
+
+            const clientOptions = {
+                host: "localhost",
+                port: 8181,
+                secure: true,
+                rejectUnauthorized: true,
+                cert: fs.readFileSync("./test/cert/testClient.cert"),
+                key: fs.readFileSync("./test/cert/testClient.key"),
+                ca: fs.readFileSync("./test/cert/testCA.cert")
+            };
+            const client = new TCPClient(clientOptions);
+            client.connect();
+
+            client.onConnect( () => {
+                client.onData( (data: Buffer) => {
+                    assert(data.toString() == "received!");
+                    client.close();
+                });
+                client.onClose( () => {
+                });
+                client.sendString("hello");
+            });
+        });
+    }
+
+    @Test()
+    public async clientserver_reject_unauthorized() {
+        await new Promise(resolve => {
+            const serverOptions = {
+                host: "localhost",
+                port: 8181,
+                requestCert: true,
+                rejectUnauthorized: true,
+                cert: fs.readFileSync("./test/cert/localhost.cert"),
+                key: fs.readFileSync("./test/cert/localhost.key"),
+                ca: fs.readFileSync("./test/cert/testCA.cert")
+            };
+            const server = new TCPServer(serverOptions);
+            server.listen();
+
+            server.onConnection( (client: Client) => {
+                client.onData( (data: Buffer) => {
+                    assert(data.toString() == "hello");
+                    client.sendString("received!");
+                });
+                client.onClose( () => {
+                    server.close();
+                    resolve();
+                });
+            });
+
+            const clientOptions = {
+                host: "localhost",
+                port: 8181,
+                secure: true,
+                rejectUnauthorized: true,
+                cert: fs.readFileSync("./test/cert/testClient.cert"),
+                key: fs.readFileSync("./test/cert/testClient.key"),
+                ca: fs.readFileSync("./test/cert/testCA.cert")
+            };
+            const client = new TCPClient(clientOptions);
+            client.connect();
+
+            client.onConnect( () => {
+                client.onData( (data: Buffer) => {
+                    assert(data.toString() == "received!");
+                    client.close();
+                });
+                client.onClose( () => {
+                });
+                client.sendString("hello");
+            });
+        });
+    }
+
+    @Test()
+    public async clientserver() {
+        await new Promise(resolve => {
+            const serverOptions = {
+                host: "localhost",
+                port: 8181,
+                requestCert: true,
+                rejectUnauthorized: false,
+                cert: fs.readFileSync("./test/cert/localhost.cert"),
+                key: fs.readFileSync("./test/cert/localhost.key")
+            };
+            const server = new TCPServer(serverOptions);
+            server.listen();
+
+            server.onConnection( (client: Client) => {
+                client.onData( (data: Buffer) => {
+                    assert(data.toString() == "hello");
+                    client.sendString("received!");
+                });
+                client.onClose( () => {
+                    server.close();
+                    resolve();
+                });
+            });
+
+            const clientOptions = {
+                host: "localhost",
+                port: 8181,
+                secure: true,
+                rejectUnauthorized: false,
+                cert: fs.readFileSync("./test/cert/testClient.cert"),
+                key: fs.readFileSync("./test/cert/testClient.key")
             };
             const client = new TCPClient(clientOptions);
             client.connect();
@@ -64,8 +214,8 @@ export class ConnectionTCPTLS {
                 port: 8181,
                 requestCert: true,
                 rejectUnauthorized: false,
-                cert: fs.readFileSync("./test/cert/test.cert"),
-                key: fs.readFileSync("./test/cert/test.key")
+                cert: fs.readFileSync("./test/cert/localhost.cert"),
+                key: fs.readFileSync("./test/cert/localhost.key")
             };
             const server = new TCPServer(serverOptions);
             server.listen();
@@ -86,8 +236,8 @@ export class ConnectionTCPTLS {
                 port: 8181,
                 secure: true,
                 rejectUnauthorized: false,
-                cert: fs.readFileSync("./test/cert/test.cert"),
-                key: fs.readFileSync("./test/cert/test.key")
+                cert: fs.readFileSync("./test/cert/testClient.cert"),
+                key: fs.readFileSync("./test/cert/testClient.key")
             };
             const client = new TCPClient(clientOptions);
             client.connect();
@@ -112,8 +262,8 @@ export class ConnectionTCPTLS {
                 port: 8181,
                 requestCert: true,
                 rejectUnauthorized: false,
-                cert: fs.readFileSync("./test/cert/test.cert"),
-                key: fs.readFileSync("./test/cert/test.key")
+                cert: fs.readFileSync("./test/cert/localhost.cert"),
+                key: fs.readFileSync("./test/cert/localhost.key")
             };
             const server = new TCPServer(serverOptions);
             server.listen();
@@ -134,8 +284,8 @@ export class ConnectionTCPTLS {
                 port: 8181,
                 secure: true,
                 rejectUnauthorized: false,
-                cert: fs.readFileSync("./test/cert/test.cert"),
-                key: fs.readFileSync("./test/cert/test.key")
+                cert: fs.readFileSync("./test/cert/testClient.cert"),
+                key: fs.readFileSync("./test/cert/testClient.key")
             };
             const client = new TCPClient(clientOptions);
             client.connect();
@@ -160,8 +310,8 @@ export class ConnectionTCPTLS {
                 port: 8181,
                 requestCert: true,
                 rejectUnauthorized: false,
-                cert: fs.readFileSync("./test/cert/test.cert"),
-                key: fs.readFileSync("./test/cert/test.key")
+                cert: fs.readFileSync("./test/cert/localhost.cert"),
+                key: fs.readFileSync("./test/cert/localhost.key")
             };
             const server = new TCPServer(serverOptions);
             server.listen();
@@ -182,8 +332,8 @@ export class ConnectionTCPTLS {
                 port: 8181,
                 secure: true,
                 rejectUnauthorized: false,
-                cert: fs.readFileSync("./test/cert/test.cert"),
-                key: fs.readFileSync("./test/cert/test.key")
+                cert: fs.readFileSync("./test/cert/testClient.cert"),
+                key: fs.readFileSync("./test/cert/testClient.key")
             };
             const client = new TCPClient(clientOptions);
             client.connect();
@@ -207,8 +357,8 @@ export class ConnectionTCPTLS {
                 port: 8182,
                 requestCert: true,
                 rejectUnauthorized: false,
-                cert: fs.readFileSync("./test/cert/test.cert"),
-                key: fs.readFileSync("./test/cert/test.key")
+                cert: fs.readFileSync("./test/cert/localhost.cert"),
+                key: fs.readFileSync("./test/cert/localhost.key")
             };
             const server = new TCPServer(serverOptions);
             server.listen();
@@ -225,8 +375,8 @@ export class ConnectionTCPTLS {
                 port: 8182,
                 secure: true,
                 rejectUnauthorized: false,
-                cert: fs.readFileSync("./test/cert/test.cert"),
-                key: fs.readFileSync("./test/cert/test.key")
+                cert: fs.readFileSync("./test/cert/testClient.cert"),
+                key: fs.readFileSync("./test/cert/testClient.key")
             };
             const client = new TCPClient(clientOptions);
             client.connect();

--- a/test/connectionTLS.spec.ts
+++ b/test/connectionTLS.spec.ts
@@ -1,0 +1,242 @@
+import { TestSuite, Test } from "testyts";
+import {WSClient} from "../index";
+import {WSServer, Client} from "../index";
+
+const assert = require("assert");
+const fs = require("fs");
+
+@TestSuite()
+export class ConnectionTLS {
+
+    @Test()
+    public async clientserver() {
+        await new Promise(resolve => {
+            const serverOptions = {
+                host: "localhost",
+                port: 8181,
+                requestCert: true,
+                rejectUnauthorized: false,
+                cert: fs.readFileSync("./test/cert/test.cert"),
+                key: fs.readFileSync("./test/cert/test.key")
+            };
+            const server = new WSServer(serverOptions);
+            server.listen();
+
+            server.onConnection( (client: Client) => {
+                client.onData( (data: Buffer) => {
+                    assert(data.toString() == "hello");
+                    client.sendString("received!");
+                });
+                client.onClose( () => {
+                    server.close();
+                    resolve();
+                });
+            });
+
+            const clientOptions = {
+                host: "localhost",
+                port: 8181,
+                secure: true,
+                rejectUnauthorized: false,
+                cert: fs.readFileSync("./test/cert/test.cert"),
+                key: fs.readFileSync("./test/cert/test.key")
+            };
+            const client = new WSClient(clientOptions);
+            client.connect();
+
+            client.onConnect( () => {
+                client.onData( (data: Buffer) => {
+                    assert(data.toString() == "received!");
+                    client.close();
+                });
+                client.onClose( () => {
+                });
+                client.sendString("hello");
+            });
+        });
+    }
+
+    @Test()
+    public async clientserver_ipv4() {
+        await new Promise(resolve => {
+            const serverOptions = {
+                host: "127.0.0.1",
+                port: 8181,
+                requestCert: true,
+                rejectUnauthorized: false,
+                cert: fs.readFileSync("./test/cert/test.cert"),
+                key: fs.readFileSync("./test/cert/test.key")
+            };
+            const server = new WSServer(serverOptions);
+            server.listen();
+
+            server.onConnection( (client: Client) => {
+                client.onData( (data: Buffer) => {
+                    assert(data.toString() == "hello");
+                    client.sendString("received!");
+                });
+                client.onClose( () => {
+                    server.close();
+                    resolve();
+                });
+            });
+
+            const clientOptions = {
+                host: "127.0.0.1",
+                port: 8181,
+                secure: true,
+                rejectUnauthorized: false,
+                cert: fs.readFileSync("./test/cert/test.cert"),
+                key: fs.readFileSync("./test/cert/test.key")
+            };
+            const client = new WSClient(clientOptions);
+            client.connect();
+
+            client.onConnect( () => {
+                client.onData( (data: Buffer) => {
+                    assert(data.toString() == "received!");
+                    client.close();
+                });
+                client.onClose( () => {
+                });
+                client.sendString("hello");
+            });
+        });
+    }
+
+    @Test()
+    public async clientserver_ipv6_short() {
+        await new Promise(resolve => {
+            const serverOptions = {
+                host: "::1",
+                port: 8181,
+                requestCert: true,
+                rejectUnauthorized: false,
+                cert: fs.readFileSync("./test/cert/test.cert"),
+                key: fs.readFileSync("./test/cert/test.key")
+            };
+            const server = new WSServer(serverOptions);
+            server.listen();
+
+            server.onConnection( (client: Client) => {
+                client.onData( (data: Buffer) => {
+                    assert(data.toString() == "hello");
+                    client.sendString("received!");
+                });
+                client.onClose( () => {
+                    server.close();
+                    resolve();
+                });
+            });
+
+            const clientOptions = {
+                host: "::1",
+                port: 8181,
+                secure: true,
+                rejectUnauthorized: false,
+                cert: fs.readFileSync("./test/cert/test.cert"),
+                key: fs.readFileSync("./test/cert/test.key")
+            };
+            const client = new WSClient(clientOptions);
+            client.connect();
+
+            client.onConnect( () => {
+                client.onData( (data: Buffer) => {
+                    assert(data.toString() == "received!");
+                    client.close();
+                });
+                client.onClose( () => {
+                });
+                client.sendString("hello");
+            });
+        });
+    }
+
+    @Test()
+    public async clientserver_ipv6_long() {
+        await new Promise(resolve => {
+            const serverOptions = {
+                host: "0:0:0:0:0:0:0:1",
+                port: 8181,
+                requestCert: true,
+                rejectUnauthorized: false,
+                cert: fs.readFileSync("./test/cert/test.cert"),
+                key: fs.readFileSync("./test/cert/test.key")
+            };
+            const server = new WSServer(serverOptions);
+            server.listen();
+
+            server.onConnection( (client: Client) => {
+                client.onData( (data: Buffer) => {
+                    assert(data.toString() == "hello");
+                    client.sendString("received!");
+                });
+                client.onClose( () => {
+                    server.close();
+                    resolve();
+                });
+            });
+
+            const clientOptions = {
+                host: "0:0:0:0:0:0:0:1",
+                port: 8181,
+                secure: true,
+                rejectUnauthorized: false,
+                cert: fs.readFileSync("./test/cert/test.cert"),
+                key: fs.readFileSync("./test/cert/test.key")
+            };
+            const client = new WSClient(clientOptions);
+            client.connect();
+
+            client.onConnect( () => {
+                client.onData( (data: Buffer) => {
+                    assert(data.toString() == "received!");
+                    client.close();
+                });
+                client.onClose( () => {
+                });
+                client.sendString("hello");
+            });
+        });
+    }
+
+    @Test()
+    public async clientserver_missing_host() {
+        await new Promise(resolve => {
+            const serverOptions = {
+                port: 8182,
+                requestCert: true,
+                rejectUnauthorized: false,
+                cert: fs.readFileSync("./test/cert/test.cert"),
+                key: fs.readFileSync("./test/cert/test.key")
+            };
+            const server = new WSServer(serverOptions);
+            server.listen();
+
+            server.onConnection( (client: Client) => {
+                client.onData( (data: Buffer) => {
+                    assert(data.toString() == "hello");
+                    server.close();
+                    resolve();
+                });
+            });
+
+            const clientOptions = {
+                port: 8182,
+                secure: true,
+                rejectUnauthorized: false,
+                cert: fs.readFileSync("./test/cert/test.cert"),
+                key: fs.readFileSync("./test/cert/test.key")
+            };
+            const client = new WSClient(clientOptions);
+            client.connect();
+
+            client.onConnect( () => {
+                client.onData( (data: Buffer) => {
+                    client.close();
+                });
+                client.sendString("hello");
+            });
+        });
+    }
+}

--- a/test/connectionTLS.spec.ts
+++ b/test/connectionTLS.spec.ts
@@ -9,15 +9,16 @@ const fs = require("fs");
 export class ConnectionTLS {
 
     @Test()
-    public async clientserver() {
+    public async clientserver_server_reject_unauthorized() {
         await new Promise(resolve => {
             const serverOptions = {
                 host: "localhost",
                 port: 8181,
                 requestCert: true,
-                rejectUnauthorized: false,
-                cert: fs.readFileSync("./test/cert/test.cert"),
-                key: fs.readFileSync("./test/cert/test.key")
+                rejectUnauthorized: true,
+                cert: fs.readFileSync("./test/cert/localhost.cert"),
+                key: fs.readFileSync("./test/cert/localhost.key"),
+                ca: fs.readFileSync("./test/cert/testCA.pem")
             };
             const server = new WSServer(serverOptions);
             server.listen();
@@ -38,8 +39,157 @@ export class ConnectionTLS {
                 port: 8181,
                 secure: true,
                 rejectUnauthorized: false,
-                cert: fs.readFileSync("./test/cert/test.cert"),
-                key: fs.readFileSync("./test/cert/test.key")
+                cert: fs.readFileSync("./test/cert/testClient.cert"),
+                key: fs.readFileSync("./test/cert/testClient.key"),
+                ca: fs.readFileSync("./test/cert/testCA.pem")
+            };
+            const client = new WSClient(clientOptions);
+            client.connect();
+
+            client.onConnect( () => {
+                client.onData( (data: Buffer) => {
+                    assert(data.toString() == "received!");
+                    client.close();
+                });
+                client.onClose( () => {
+                });
+                client.sendString("hello");
+            });
+        });
+    }
+
+    @Test()
+    public async clientserver_client_reject_unauthorized() {
+        await new Promise(resolve => {
+            const serverOptions = {
+                host: "localhost",
+                port: 8181,
+                requestCert: true,
+                rejectUnauthorized: false,
+                cert: fs.readFileSync("./test/cert/localhost.cert"),
+                key: fs.readFileSync("./test/cert/localhost.key"),
+                ca: fs.readFileSync("./test/cert/testCA.pem")
+            };
+            const server = new WSServer(serverOptions);
+            server.listen();
+
+            server.onConnection( (client: Client) => {
+                client.onData( (data: Buffer) => {
+                    assert(data.toString() == "hello");
+                    client.sendString("received!");
+                });
+                client.onClose( () => {
+                    server.close();
+                    resolve();
+                });
+            });
+
+            const clientOptions = {
+                host: "localhost",
+                port: 8181,
+                secure: true,
+                rejectUnauthorized: true,
+                cert: fs.readFileSync("./test/cert/testClient.cert"),
+                key: fs.readFileSync("./test/cert/testClient.key"),
+                ca: fs.readFileSync("./test/cert/testCA.pem")
+            };
+            const client = new WSClient(clientOptions);
+            client.connect();
+
+            client.onConnect( () => {
+                client.onData( (data: Buffer) => {
+                    assert(data.toString() == "received!");
+                    client.close();
+                });
+                client.onClose( () => {
+                });
+                client.sendString("hello");
+            });
+        });
+    }
+
+    @Test()
+    public async clientserver_reject_unauthorized() {
+        await new Promise(resolve => {
+            const serverOptions = {
+                host: "localhost",
+                port: 8181,
+                requestCert: true,
+                rejectUnauthorized: true,
+                cert: fs.readFileSync("./test/cert/localhost.cert"),
+                key: fs.readFileSync("./test/cert/localhost.key"),
+                ca: fs.readFileSync("./test/cert/testCA.pem")
+            };
+            const server = new WSServer(serverOptions);
+            server.listen();
+
+            server.onConnection( (client: Client) => {
+                client.onData( (data: Buffer) => {
+                    assert(data.toString() == "hello");
+                    client.sendString("received!");
+                });
+                client.onClose( () => {
+                    server.close();
+                    resolve();
+                });
+            });
+
+            const clientOptions = {
+                host: "localhost",
+                port: 8181,
+                secure: true,
+                rejectUnauthorized: true,
+                cert: fs.readFileSync("./test/cert/testClient.cert"),
+                key: fs.readFileSync("./test/cert/testClient.key"),
+                ca: fs.readFileSync("./test/cert/testCA.pem")
+            };
+            const client = new WSClient(clientOptions);
+            client.connect();
+
+            client.onConnect( () => {
+                client.onData( (data: Buffer) => {
+                    assert(data.toString() == "received!");
+                    client.close();
+                });
+                client.onClose( () => {
+                });
+                client.sendString("hello");
+            });
+        });
+    }
+
+    @Test()
+    public async clientserver_allow_unauthorized() {
+        await new Promise(resolve => {
+            const serverOptions = {
+                host: "localhost",
+                port: 8181,
+                requestCert: true,
+                rejectUnauthorized: false,
+                cert: fs.readFileSync("./test/cert/localhost.cert"),
+                key: fs.readFileSync("./test/cert/localhost.key")
+            };
+            const server = new WSServer(serverOptions);
+            server.listen();
+
+            server.onConnection( (client: Client) => {
+                client.onData( (data: Buffer) => {
+                    assert(data.toString() == "hello");
+                    client.sendString("received!");
+                });
+                client.onClose( () => {
+                    server.close();
+                    resolve();
+                });
+            });
+
+            const clientOptions = {
+                host: "localhost",
+                port: 8181,
+                secure: true,
+                rejectUnauthorized: false,
+                cert: fs.readFileSync("./test/cert/testClient.cert"),
+                key: fs.readFileSync("./test/cert/testClient.key")
             };
             const client = new WSClient(clientOptions);
             client.connect();
@@ -64,8 +214,8 @@ export class ConnectionTLS {
                 port: 8181,
                 requestCert: true,
                 rejectUnauthorized: false,
-                cert: fs.readFileSync("./test/cert/test.cert"),
-                key: fs.readFileSync("./test/cert/test.key")
+                cert: fs.readFileSync("./test/cert/localhost.cert"),
+                key: fs.readFileSync("./test/cert/localhost.key")
             };
             const server = new WSServer(serverOptions);
             server.listen();
@@ -86,8 +236,8 @@ export class ConnectionTLS {
                 port: 8181,
                 secure: true,
                 rejectUnauthorized: false,
-                cert: fs.readFileSync("./test/cert/test.cert"),
-                key: fs.readFileSync("./test/cert/test.key")
+                cert: fs.readFileSync("./test/cert/testClient.cert"),
+                key: fs.readFileSync("./test/cert/testClient.key")
             };
             const client = new WSClient(clientOptions);
             client.connect();
@@ -112,8 +262,8 @@ export class ConnectionTLS {
                 port: 8181,
                 requestCert: true,
                 rejectUnauthorized: false,
-                cert: fs.readFileSync("./test/cert/test.cert"),
-                key: fs.readFileSync("./test/cert/test.key")
+                cert: fs.readFileSync("./test/cert/localhost.cert"),
+                key: fs.readFileSync("./test/cert/localhost.key")
             };
             const server = new WSServer(serverOptions);
             server.listen();
@@ -134,8 +284,8 @@ export class ConnectionTLS {
                 port: 8181,
                 secure: true,
                 rejectUnauthorized: false,
-                cert: fs.readFileSync("./test/cert/test.cert"),
-                key: fs.readFileSync("./test/cert/test.key")
+                cert: fs.readFileSync("./test/cert/testClient.cert"),
+                key: fs.readFileSync("./test/cert/testClient.key")
             };
             const client = new WSClient(clientOptions);
             client.connect();
@@ -160,8 +310,8 @@ export class ConnectionTLS {
                 port: 8181,
                 requestCert: true,
                 rejectUnauthorized: false,
-                cert: fs.readFileSync("./test/cert/test.cert"),
-                key: fs.readFileSync("./test/cert/test.key")
+                cert: fs.readFileSync("./test/cert/localhost.cert"),
+                key: fs.readFileSync("./test/cert/localhost.key")
             };
             const server = new WSServer(serverOptions);
             server.listen();
@@ -182,8 +332,8 @@ export class ConnectionTLS {
                 port: 8181,
                 secure: true,
                 rejectUnauthorized: false,
-                cert: fs.readFileSync("./test/cert/test.cert"),
-                key: fs.readFileSync("./test/cert/test.key")
+                cert: fs.readFileSync("./test/cert/testClient.cert"),
+                key: fs.readFileSync("./test/cert/testClient.key")
             };
             const client = new WSClient(clientOptions);
             client.connect();
@@ -207,8 +357,8 @@ export class ConnectionTLS {
                 port: 8182,
                 requestCert: true,
                 rejectUnauthorized: false,
-                cert: fs.readFileSync("./test/cert/test.cert"),
-                key: fs.readFileSync("./test/cert/test.key")
+                cert: fs.readFileSync("./test/cert/localhost.cert"),
+                key: fs.readFileSync("./test/cert/localhost.key")
             };
             const server = new WSServer(serverOptions);
             server.listen();
@@ -225,8 +375,8 @@ export class ConnectionTLS {
                 port: 8182,
                 secure: true,
                 rejectUnauthorized: false,
-                cert: fs.readFileSync("./test/cert/test.cert"),
-                key: fs.readFileSync("./test/cert/test.key")
+                cert: fs.readFileSync("./test/cert/testClient.cert"),
+                key: fs.readFileSync("./test/cert/testClient.key")
             };
             const client = new WSClient(clientOptions);
             client.connect();


### PR DESCRIPTION
+ Add script to generate self-signed certificates, including a locally available _Certificate Authority_, and keys for both server and client under _test/cert_

* Update _README_ to mention the new `generate_self_signed_cert.sh` script

* Fix typo in _types_ comment blocks

This request also adds _TCP_ and _WS_ server and client tests to cover all combinations of `rejectUnauthorized` (certification and keys checking).