### PR TITLE
Improve types for event handling and simplify events

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The overall interface for _pocket-sockets_ _WebSocket_ and _TCP_ sockets **are i
 ## Example
 For a quick glimpse of what it looks like to set up a server that receives a string from clients, then replies back and closes the connection afterwards, follow the example below:
 ```typescript
-import {WSServer, WSClient, Client} from "pocket-sockets";
+import {WSServer, WSClient, ClientInterface} from "pocket-sockets";
 
 const server = new WSServer({
     host: "localhost",
@@ -28,9 +28,9 @@ const server = new WSServer({
 });
 server.listen();
 
-server.onConnection( (client: Client) => {
-    client.onData( (data: Buffer) => {
-        client.sendString("This is server: received!");
+server.onConnection( (client: ClientInterface) => {
+    client.onData( (data: Buffer | string) => {
+        client.send("This is server: received!");
     });
     client.onClose( () => {
         server.close();
@@ -44,10 +44,10 @@ const client = new WSClient({
 client.connect();
 
 client.onConnect( () => {
-    client.onData( (data: Buffer) => {
+    client.onData( (data: Buffer | string) => {
         client.close();
     });
-    client.sendString("This is client: hello");
+    client.send("This is client: hello");
 });
 ```
 

--- a/example/example-tcp.ts
+++ b/example/example-tcp.ts
@@ -15,22 +15,24 @@
 //   Client: closed
 //
 
-import {TCPServer, TCPClient, Client} from "../index";
+import {TCPServer, TCPClient, ClientInterface} from "../index";
 
 console.log("pocket-sockets: TCP example");
 const serverOptions = {
     host: "localhost",
-    port: 8181
+    port: 8181,
+    // If wanting to send/recieve in text-mode set textMode to true.
+    //textMode: true,
 };
 const server = new TCPServer(serverOptions);
 server.listen();
 console.log("Server: listening...");
 
-server.onConnection( (client: Client) => {
+server.onConnection( (client: ClientInterface) => {
     console.log("Server: socket accepted");
-    client.onData( (data: Buffer) => {
+    client.onData( (data: Buffer | string) => {
         console.log("Server: incoming client data", data);
-        client.sendString("This is server: received!");
+        client.send("This is server: received!");
     });
     client.onClose( () => {
         console.log("Server: client connection closed");
@@ -40,7 +42,9 @@ server.onConnection( (client: Client) => {
 
 const clientOptions = {
     host: "localhost",
-    port: 8181
+    port: 8181,
+    // If wanting to send/recieve in text-mode set textMode to true.
+    //textMode: true,
 };
 const client = new TCPClient(clientOptions);
 client.connect();
@@ -48,12 +52,12 @@ console.log("Client: connecting...");
 
 client.onConnect( () => {
     console.log("Client: connected");
-    client.onData( (data: Buffer) => {
+    client.onData( (data: Buffer | string) => {
         console.log("Client: incoming server data", data);
         client.close();
     });
     client.onClose( () => {
         console.log("Client: closed");
     });
-    client.sendString("This is client: hello");
+    client.send("This is client: hello");
 });

--- a/example/example-ws.ts
+++ b/example/example-ws.ts
@@ -15,22 +15,24 @@
 //   Server: client connection closed
 //
 
-import {WSServer, WSClient, Client} from "../index";
+import {WSServer, WSClient, ClientInterface} from "../index";
 
 console.log("pocket-sockets: WS example");
 const serverOptions = {
     host: "localhost",
-    port: 8181
+    port: 8181,
+    // If wanting to send/recieve in text-mode set textMode to true.
+    //textMode: true,
 };
 const server = new WSServer(serverOptions);
 server.listen();
 console.log("Server: listening...");
 
-server.onConnection( (client: Client) => {
+server.onConnection( (client: ClientInterface) => {
     console.log("Server: socket accepted");
-    client.onData( (data: Buffer) => {
+    client.onData( (data: Buffer | string) => {
         console.log("Server: incoming client data", data);
-        client.sendString("This is server: received!");
+        client.send("This is server: received!");
     });
     client.onClose( () => {
         console.log("Server: client connection closed");
@@ -40,7 +42,9 @@ server.onConnection( (client: Client) => {
 
 const clientOptions = {
     host: "localhost",
-    port: 8181
+    port: 8181,
+    // If wanting to send/recieve in text-mode set textMode to true.
+    //textMode: true,
 };
 const client = new WSClient(clientOptions);
 client.connect();
@@ -48,12 +52,12 @@ console.log("Client: connecting...");
 
 client.onConnect( () => {
     console.log("Client: connected");
-    client.onData( (data: Buffer) => {
+    client.onData( (data: Buffer | string) => {
         console.log("Client: incoming server data", data);
         client.close();
     });
     client.onClose( () => {
         console.log("Client: closed");
     });
-    client.sendString("This is client: hello");
+    client.send("This is client: hello");
 });

--- a/src/Server.ts
+++ b/src/Server.ts
@@ -3,7 +3,7 @@ import {
     ServerOptions,
     SocketErrorCallback,
     SocketCloseCallback,
-    SocketAcceptedCallback,
+    SocketAcceptCallback,
 } from "./types";
 
 /**
@@ -61,7 +61,7 @@ export abstract class Server
      *
      * @param {Function} fn callback
      */
-    public onConnection(fn: SocketAcceptedCallback) {
+    public onConnection(fn: SocketAcceptCallback) {
         this.on("connection", fn);
     }
 
@@ -117,7 +117,9 @@ export abstract class Server
      * @param {Error} err
      */
     protected serverError = (message: string) => {
-        this.triggerEvent("error", message);
+        const errorEvent: Parameters<SocketErrorCallback> = [message];
+
+        this.triggerEvent("error", ...errorEvent);
     }
 
     /**
@@ -136,7 +138,10 @@ export abstract class Server
     protected addClient(client: ClientInterface) {
         this.clients.push(client);
         client.onClose( () => { this.removeClient(client) } );
-        this.triggerEvent("connection", client);
+
+        const socketAcceptedEvent: Parameters<SocketAcceptCallback> = [client];
+
+        this.triggerEvent("connection", ...socketAcceptedEvent);
     }
 
     /**

--- a/src/TCPClient.ts
+++ b/src/TCPClient.ts
@@ -119,6 +119,10 @@ export class TCPClient extends Client
         this.socket.on("close", this.socketClosed);         // Socket closed
     }
 
+    protected unhookError() {
+        this.socket?.off("error", this.error);
+    }
+
     /**
      * Defines how data gets written to the socket.
      *
@@ -147,6 +151,6 @@ export class TCPClient extends Client
     }
 
     protected error = (error: Error) => {
-        this.socketError(error.message);
+        this.socketError(error.message || "TCP socket could not connect");
     };
 }

--- a/src/WSClient.ts
+++ b/src/WSClient.ts
@@ -199,6 +199,12 @@ export class WSClient extends Client
         this.socket.onclose = (closeEvent) => this.socketClosed(closeEvent && closeEvent.code === 1000);         // Socket closed
     }
 
+    protected unhookError() {
+        if (this.socket) {
+            this.socket.onerror = null;
+        }
+    }
+
     /**
      * Defines how data gets written to the socket.
      * @param {data} buffer or string - data to be sent
@@ -236,6 +242,6 @@ export class WSClient extends Client
     }
 
     protected error = (error: ws.ErrorEvent) => {
-        this.socketError(error.message || "Unknown error message");
+        this.socketError(error.message || error.error || "WebSocket could not connect");
     };
 }

--- a/src/WrappedClient.ts
+++ b/src/WrappedClient.ts
@@ -12,8 +12,6 @@ import {
  * specific methods can be overriden to transform incoming and outgoint socket data.
  */
 export class WrappedClient implements WrappedClientInterface {
-    protected handlers: {[name: string]: ((args?: any) => void)[]} = {};
-
     constructor(protected client: ClientInterface) {}
 
     public getClient(): ClientInterface {
@@ -101,23 +99,5 @@ export class WrappedClient implements WrappedClientInterface {
 
     public getLocalPort(): number | undefined {
         return this.client.getLocalPort();
-    }
-
-    protected hookEvent(type: string, callback: (args?: any) => void) {
-        const cbs = this.handlers[type] || [];
-        this.handlers[type] = cbs;
-        cbs.push(callback);
-    }
-
-    protected unhookEvent(type: string, callback: (args?: any) => void) {
-        const cbs = (this.handlers[type] || []).filter( (cb: (args?: any) => void) => callback !== cb );
-        this.handlers[type] = cbs;
-    }
-
-    protected triggerEvent(type: string, ...args: any) {
-        const cbs = this.handlers[type] || [];
-        cbs.forEach( (callback) => {
-            callback(...args);
-        });
     }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,93 +1,93 @@
-/** Event emitted on client socket connect error. */
+export const SOCKET_WEBSOCKET = "WebSocket";
+export const SOCKET_TCP = "TCP";
+
+/**
+ * Event emitted on client socket connect error.
+ * @param message potential error message
+ */
 export type SocketErrorCallback = (message: string) => void;
 
-/** Event emitted on incoming binary data on socket. */
+/**
+ * Event emitted on incoming binary or text data on client socket.
+ * @param data incoming data as Buffer or text (depending on socket configuration)
+ */
 export type SocketDataCallback = (data: Buffer | string) => void;
 
-/** Event emitted on socket connected. */
+/**
+ * Event emitted on client socket connect.
+ */
 export type SocketConnectCallback = () => void;
 
-/** Event emitted on socket close. */
+/**
+ * Event emitted on client socket close.
+ * @param hadError set to true if the socket was closed due to an error.
+ */
 export type SocketCloseCallback = (hadError: boolean) => void;
 
-/** Event emitted on server socket accepted. */
-export type SocketAcceptedCallback = (client: ClientInterface) => void;
-
 /**
- * A map over all events emitted from this SocketFactory.
- * The ERROR events is special that it is emitted together with a specific error event.
+ * Event emitted on server socket accepted.
+ * @param client the newly accepted and created client socket
  */
-export const EVENTS = {
-    ERROR: {
-        name: "ERROR",
-        /* These are the names of the events which also are emitted as ERROR events. */
-        subEvents: [
-            "CLIENT_INIT_ERROR",
-            "CLIENT_CONNECT_ERROR",
-            "SERVER_INIT_ERROR",
-            "SERVER_LISTEN_ERROR",
-        ],
-    },
-    CLIENT_INIT_ERROR: {
-        name: "CLIENT_INIT_ERROR",
-    },
-    CLIENT_CONNECT_ERROR: {
-        name: "CLIENT_CONNECT_ERROR",
-    },
-    CLOSE: {
-        name: "CLOSE",
-    },
-    CONNECT: {
-        name: "CONNECT",
-    },
-    SERVER_INIT_ERROR: {
-        name: "SERVER_INIT_ERROR",
-    },
-    SERVER_LISTEN_ERROR: {
-        name: "SERVER_LISTEN_ERROR",
-    },
-    CLIENT_REFUSE: {
-        name: "CLIENT_REFUSE",
-        reason: {
-            IP_DENIED: "IP_DENIED",
-            IP_NOT_ALLOWED: "IP_NOT_ALLOWED",
-            IP_OVERFLOW: "IP_OVERFLOW",
-        },
-    },
-};
+export type SocketAcceptCallback = (client: ClientInterface) => void;
 
-/**
- * This error event is always emitted in addition to every specific error event.
- * It is a good catch-all error event handler.
- * @param e.subEvent is the name of the specific error event which was emitted.
- * These options are in EVENTS.ERROR.subEvents list.
- * @param e.e is the original event parameter(s) passed on in an object.
- */
-export type ErrorCallback = (e: {subEvent: string, e: {error: Error}}) => void;
+export const EVENT_SOCKETFACTORY_ERROR = "ERROR";
+export const EVENT_SOCKETFACTORY_CLOSE = "CLOSE";
+export const EVENT_SOCKETFACTORY_CONNECT = "CONNECT";
+export const EVENT_SOCKETFACTORY_CLIENT_INIT_ERROR = "CLIENT_INIT_ERROR";
+export const EVENT_SOCKETFACTORY_CLIENT_CONNECT_ERROR = "CLIENT_CONNECT_ERROR";
+export const EVENT_SOCKETFACTORY_CLIENT_IP_REFUSE = "CLIENT_IP_REFUSE";
+export const EVENT_SOCKETFACTORY_SERVER_INIT_ERROR = "SERVER_INIT_ERROR";
+export const EVENT_SOCKETFACTORY_SERVER_LISTEN_ERROR = "SERVER_LISTEN_ERROR";
+
+export const DETAIL_SOCKETFACTORY_CLIENT_REFUSE_ERROR_IP_DENIED = "IP_DENIED";
+export const DETAIL_SOCKETFACTORY_CLIENT_REFUSE_ERROR_IP_NOT_ALLOWED = "IP_NOT_ALLOWED";
+export const DETAIL_SOCKETFACTORY_CLIENT_REFUSE_ERROR_IP_OVERFLOW = "IP_OVERFLOW";
 
 /** Event emitted when client socket cannot be initaited, likely due to misconfiguration. */
-export type ClientInitErrorCallback = (e: {error: Error}) => void;
+export type SocketFactoryClientInitErrorCallback = (error: Error) => void;
 
 /** Event emitted when client socket cannot connect to server. */
-export type ClientConnectErrorCallback = (error: Error) => void;
+export type SocketFactoryClientConnectErrorCallback = (error: Error) => void;
 
 /** Event emitted when client socket connected. */
-export type ConnectCallback = (e: {client: ClientInterface, isServer: boolean}) => void;
+export type SocketFactoryConnectCallback = (client: ClientInterface, isServer: boolean) => void;
 
 /** Event emitted when either client or server accepted socket is closed. */
-export type CloseCallback = (e: {client: ClientInterface, isServer: boolean, hadError: boolean}) => void;
+export type SocketFactoryCloseCallback = (client: ClientInterface, isServer: boolean, hadError: boolean) => void;
 
 /** Event emitted when server socket cannot be created. */
-export type ServerInitErrorCallback = (error: Error) => void;
+export type SocketFactoryServerInitErrorCallback = (error: Error) => void;
 
 /** Event emitted when server socket cannot bind and listen, could be that port is taken. */
-export type ServerListenErrorCallback = (error: Error) => void;
+export type SocketFactoryServerListenErrorCallback = (error: Error) => void;
+
+export type SocketFactoryClientIPRefuseDetail =
+    typeof DETAIL_SOCKETFACTORY_CLIENT_REFUSE_ERROR_IP_DENIED |
+    typeof DETAIL_SOCKETFACTORY_CLIENT_REFUSE_ERROR_IP_NOT_ALLOWED |
+    typeof DETAIL_SOCKETFACTORY_CLIENT_REFUSE_ERROR_IP_OVERFLOW;
 
 /**
- * Event emitted when server actively refused the client's IP address.
- * @reason is found in EVENTS.CLIENT_REFUSE.reason
+ * Event emitted when server actively refused the client's IP address for a specific reason.
+ * @param detail the reason why the IP address got refused to connect
+ * @param ipAddress the textual IP address getting refused
  */
-export type ClientRefuseCallback = (e: {reason: string, key: string}) => void;
+export type SocketFactoryClientIPRefuseCallback = (detail: SocketFactoryClientIPRefuseDetail, ipAddress: string) => void;
+
+export type SocketFactoryErrorCallbackNames = 
+    typeof EVENT_SOCKETFACTORY_CLIENT_INIT_ERROR |
+    typeof EVENT_SOCKETFACTORY_CLIENT_CONNECT_ERROR |
+    typeof EVENT_SOCKETFACTORY_SERVER_INIT_ERROR |
+    typeof EVENT_SOCKETFACTORY_SERVER_LISTEN_ERROR;
+
+/**
+ * The error event is always emitted in addition to every specific error event in the SocketFactory.
+ * It works as a catch-all error event handler.
+ *
+ * @param name is the name of the specific error event which was emitted
+ * @param error is the original event error argument
+ */
+export type SocketFactoryErrorCallback =
+    (name: SocketFactoryErrorCallbackNames, error: Error) => void;
 
 export interface ClientInterface {
     init(): Promise<void>;
@@ -121,14 +121,19 @@ export interface SocketFactoryInterface {
     isClosed(): boolean;
     isShutdown(): boolean;
     getStats(): SocketFactoryStats;
-    onError(callback: ErrorCallback): void;
-    onServerInitError(callback: ServerInitErrorCallback): void;
-    onServerListenError(callback: ServerListenErrorCallback): void;
-    onClientInitError(callback: ClientInitErrorCallback): void;
-    onConnectError(callback: ClientConnectErrorCallback): void;
-    onConnect(callback: ConnectCallback): void;
-    onClose(callback: CloseCallback): void;
-    onRefusedClientConnection(callback: ClientRefuseCallback): void;
+
+    /** Catch-all error handler for SocketFactory. */
+    onSocketFactoryError(callback: SocketFactoryErrorCallback): void;
+
+    onServerInitError(callback: SocketFactoryServerInitErrorCallback): void;
+    onServerListenError(callback: SocketFactoryServerListenErrorCallback): void;
+    onClientInitError(callback: SocketFactoryClientInitErrorCallback): void;
+    onConnectError(callback: SocketFactoryClientConnectErrorCallback): void;
+    onConnect(callback: SocketFactoryConnectCallback): void;
+    onClose(callback: SocketFactoryCloseCallback): void;
+
+    /** Event called when connecting peer has been refused. */
+    onClientIPRefuse(callback: SocketFactoryClientIPRefuseCallback): void;
 }
 
 export interface WrappedClientInterface extends ClientInterface {
@@ -292,7 +297,7 @@ export type SocketFactoryConfig = {
      * Both client and server can bet set together.
      */
     client?: {
-        socketType: "WebSocket" | "TCP",
+        socketType: typeof SOCKET_WEBSOCKET | typeof SOCKET_TCP,
 
         clientOptions: ClientOptions,
 
@@ -305,7 +310,7 @@ export type SocketFactoryConfig = {
      * Both client and server can bet set together.
      */
     server?: {
-        socketType: "WebSocket" | "TCP",
+        socketType: typeof SOCKET_WEBSOCKET | typeof SOCKET_TCP,
 
         serverOptions: ServerOptions,
 

--- a/test/Client.spec.ts
+++ b/test/Client.spec.ts
@@ -54,6 +54,8 @@ export class ClientConnect {
             }
             socketHook() {
             }
+            unhookError() {
+            }
         }
 
         assert.doesNotThrow(() => {
@@ -75,6 +77,8 @@ export class ClientConnect {
             }
             socketHook() {
                 flag = true;
+            }
+            unhookError() {
             }
         }
 
@@ -105,6 +109,8 @@ export class ClientSend {
             }
             socketHook() {
             }
+            unhookError() {
+            }
         }
 
         assert.doesNotThrow(() => {
@@ -128,6 +134,8 @@ export class ClientSend {
             socketConnect() {
             }
             socketHook() {
+            }
+            unhookError() {
             }
         }
 
@@ -160,6 +168,8 @@ export class ClientSendString {
             }
             socketHook() {
             }
+            unhookError() {
+            }
         }
 
         assert.doesNotThrow(() => {
@@ -184,6 +194,8 @@ export class ClientClose {
             socketConnect() {
             }
             socketHook() {
+            }
+            unhookError() {
             }
             _socketClose() {
                 flag = true;
@@ -212,6 +224,8 @@ export class ClientClose {
             }
             socketHook() {
             }
+            unhookError() {
+            }
             socketClose() {
                 flag = true;
             }
@@ -235,6 +249,8 @@ export class ClientClose {
             socketConnect() {
             }
             socketHook() {
+            }
+            unhookError() {
             }
             socketClose() {
                 flag = true;
@@ -265,6 +281,8 @@ export class ClientOnError {
             }
             socketHook() {
             }
+            unhookError() {
+            }
             on(evt: string, fn: Function) {
                 assert(evt == "error");
                 assert(fn instanceof Function);
@@ -294,6 +312,8 @@ export class ClientOffError {
             }
             socketHook() {
             }
+            unhookError() {
+            }
             on(evt: string, fn: Function) {
                 assert(evt == "error");
                 assert(fn instanceof Function);
@@ -322,6 +342,8 @@ export class ClientOnData {
             }
             socketHook() {
             }
+            unhookError() {
+            }
             on(evt: string, fn: Function) {
                 assert(evt == "data");
                 assert(fn instanceof Function);
@@ -349,6 +371,8 @@ export class ClientOffData {
                 socketConnect() {
                 }
                 socketHook() {
+                }
+                unhookError() {
                 }
                 on(evt: string, fn: Function) {
                     assert(evt == "data");
@@ -379,6 +403,8 @@ export class ClientOnConnect {
             }
             socketHook() {
             }
+            unhookError() {
+            }
             on(evt: string, fn: Function) {
                 assert(evt == "connect");
                 assert(fn instanceof Function);
@@ -406,6 +432,8 @@ export class ClientOffConnect {
             socketConnect() {
             }
             socketHook() {
+            }
+            unhookError() {
             }
             on(evt: string, fn: Function) {
                 assert(evt == "connect");
@@ -435,6 +463,8 @@ export class ClientOnClose {
             }
             socketHook() {
             }
+            unhookError() {
+            }
             on(evt: string, fn: Function) {
                 assert(evt == "close");
                 assert(fn instanceof Function);
@@ -463,6 +493,8 @@ export class ClientOffClose {
             }
             socketHook() {
             }
+            unhookError() {
+            }
             on(evt: string, fn: Function) {
                 assert(evt == "close");
                 assert(fn instanceof Function);
@@ -489,6 +521,8 @@ export class ClientOn {
             }
             socketHook() {
             }
+            unhookError() {
+            }
         }
 
         assert.doesNotThrow(() => {
@@ -514,6 +548,8 @@ export class ClientOff {
             socketConnect() {
             }
             socketHook() {
+            }
+            unhookError() {
             }
         }
 
@@ -547,6 +583,8 @@ export class ClientCloseInner {
             }
             socketHook() {
             }
+            unhookError() {
+            }
         }
 
         assert.doesNotThrow(() => {
@@ -574,6 +612,8 @@ export class ClientData {
             socketConnect() {
             }
             socketHook() {
+            }
+            unhookError() {
             }
             triggerEvent(evt: string) {
                 assert(evt == "data");
@@ -605,6 +645,8 @@ export class ClientConnectInner {
             }
             socketHook() {
             }
+            unhookError() {
+            }
             triggerEvent(evt: string) {
                 assert(evt == "connect");
                 flag = true;
@@ -631,6 +673,8 @@ export class ClientError {
             socketConnect() {
             }
             socketHook() {
+            }
+            unhookError() {
             }
             triggerEvent(evt: string) {
                 assert(evt == "error");
@@ -695,6 +739,8 @@ export class ClientSocketClosed {
             }
             socketHook() {
             }
+            unhookError() {
+            }
             triggerEvent(evt: string, data: boolean) {
                 flagOnEvent = true;
                 assert(evt == "close");
@@ -730,6 +776,8 @@ export class ClientSocketConnected {
             }
             socketHook() {
             }
+            unhookError() {
+            }
             triggerEvent(evt: string, data: any) {
                 flagOnEvent = true;
                 assert(evt == "connect");
@@ -761,6 +809,8 @@ export class ClientSocketError {
             }
             socketHook() {
             }
+            unhookError() {
+            }
             triggerEvent(evt: string, data: Buffer) {
                 flagOnEvent = true;
                 assert(evt == "error");
@@ -790,6 +840,8 @@ export class ClientTriggerEvent {
             socketConnect() {
             }
             socketHook() {
+            }
+            unhookError() {
             }
         }
 

--- a/test/SocketFactory.spec.ts
+++ b/test/SocketFactory.spec.ts
@@ -1,4 +1,4 @@
-import { TestSuite, Test, FTest } from "testyts";
+import { TestSuite, Test } from "testyts";
 import {SocketFactory} from "../src/SocketFactory";
 
 import {

--- a/test/SocketFactory.spec.ts
+++ b/test/SocketFactory.spec.ts
@@ -1,4 +1,4 @@
-import { TestSuite, Test } from "testyts";
+import { TestSuite, Test, FTest } from "testyts";
 import {SocketFactory} from "../src/SocketFactory";
 
 import {
@@ -477,12 +477,15 @@ export class SocketFactoryConnectClient {
                 initClientSocketCalled = true;
             };
             //@ts-ignore
-            socketFactory.triggerEvent = function(name, args) {
+            socketFactory.triggerEvent = function(name, ...args: any[]) {
                 assert(name == "CLIENT_INIT_ERROR" || name == "ERROR");
-                if(args.e && args.e.error) {
-                    assert(args.e.error.message == "test");
-                } else {
-                    assert(args.error.message == "test");
+
+                if (name == "CLIENT_INIT_ERROR") {
+                    assert(args[0].message == "test");
+                }
+                else {
+                    assert(args[0] == "CLIENT_INIT_ERROR");
+                    assert(args[1].message == "test");
                 }
             };
 
@@ -672,12 +675,15 @@ export class SocketFactoryInitClientSocket {
             });
 
             //@ts-ignore
-            socketFactory.triggerEvent = function(name, args) {
+            socketFactory.triggerEvent = function(name, ...args: any[]) {
                 assert(name == "CLIENT_CONNECT_ERROR" || name == "ERROR");
-                if(args.e && args.e.error) {
-                    assert(args.e.error.message == "test");
-                } else {
-                    assert(args.error.message == "test");
+
+                if (name == "CLIENT_CONNECT_ERROR") {
+                    assert(args[0].message == "test");
+                }
+                else {
+                    assert(args[0] == "CLIENT_CONNECT_ERROR");
+                    assert(args[1].message == "test");
                 }
             };
 
@@ -726,12 +732,15 @@ export class SocketFactoryInitClientSocket {
             });
 
             //@ts-ignore
-            socketFactory.triggerEvent = function(name, args) {
+            socketFactory.triggerEvent = function(name, ...args: any[]) {
                 assert(name == "CLIENT_CONNECT_ERROR" || name == "ERROR");
-                if(args.e && args.e.error) {
-                    assert(args.e.error.message == "test");
-                } else {
-                    assert(args.error.message == "test");
+
+                if (name == "CLIENT_CONNECT_ERROR") {
+                    assert(args[0].message == "test");
+                }
+                else {
+                    assert(args[0] == "CLIENT_CONNECT_ERROR");
+                    assert(args[1].message == "test");
                 }
             };
 
@@ -780,12 +789,15 @@ export class SocketFactoryInitClientSocket {
             });
 
             //@ts-ignore
-            socketFactory.triggerEvent = function(name, args) {
+            socketFactory.triggerEvent = function(name, ...args: any[]) {
                 assert(name == "CLIENT_CONNECT_ERROR" || name == "ERROR");
-                if(args.e && args.e.error) {
-                    assert(args.e.error.message == "test");
-                } else {
-                    assert(args.error.message == "test");
+
+                if (name == "CLIENT_CONNECT_ERROR") {
+                    assert(args[0].message == "test");
+                }
+                else {
+                    assert(args[0] == "CLIENT_CONNECT_ERROR");
+                    assert(args[1].message == "test");
                 }
             };
 
@@ -798,9 +810,16 @@ export class SocketFactoryInitClientSocket {
                 assert(host == "host.com");
             };
             //@ts-ignore
-            socketFactory.triggerEvent = function(name, args) {
+            socketFactory.triggerEvent = function(name, ...args: any[]) {
                 assert(name == "ERROR" || name == "CONNECT");
-                assert(args.isServer == false);
+
+                if (name === "CONNECT") {
+                    assert(args[1] == false);
+                }
+                else {
+                    assert(args[0] == "CONNECT");
+                    assert(args[1] == false);
+                }
             };
 
             let onErrorCalled = false;
@@ -853,12 +872,15 @@ export class SocketFactoryInitClientSocket {
             });
 
             //@ts-ignore
-            socketFactory.triggerEvent = function(name, args) {
+            socketFactory.triggerEvent = function(name, ...args: any[]) {
                 assert(name == "CLIENT_CONNECT_ERROR" || name == "ERROR");
-                if(args.e && args.e.error) {
-                    assert(args.e.error.message == "test");
-                } else {
-                    assert(args.error.message == "test");
+
+                if (name == "CLIENT_CONNECT_ERROR") {
+                    assert(args[0].message == "test");
+                }
+                else {
+                    assert(args[0] == "CLIENT_CONNECT_ERROR");
+                    assert(args[1].message == "test");
                 }
             };
 
@@ -871,9 +893,16 @@ export class SocketFactoryInitClientSocket {
                 assert(host == "host.com");
             };
             //@ts-ignore
-            socketFactory.triggerEvent = function(name, args) {
+            socketFactory.triggerEvent = function(name, ...args: any[]) {
                 assert(name == "ERROR" || name == "CONNECT");
-                assert(args.isServer == false);
+
+                if (name == "CONNECT") {
+                    assert(args[1] == false);
+                }
+                else {
+                    assert(args[0] == "CONNECT");
+                    assert(args[1] == false);
+                }
             };
 
             let onErrorCalled = false;
@@ -1126,12 +1155,15 @@ export class SocketFactoryOpenServer {
             };
 
             //@ts-ignore
-            socketFactory.triggerEvent = function(name, args) {
+            socketFactory.triggerEvent = function(name, ...args: any[]) {
                 assert(name == "SERVER_INIT_ERROR" || name == "ERROR");
-                if(args.e && args.e.error) {
-                    assert(args.e.error.message == "test");
-                } else {
-                    assert(args.error.message == "test");
+
+                if (name == "SERVER_INIT_ERROR") {
+                    assert(args[0].message == "test");
+                }
+                else {
+                    assert(args[0] == "SERVER_INIT_ERROR");
+                    assert(args[1].message == "test");
                 }
             };
 
@@ -1980,7 +2012,7 @@ export class SocketFactoryOnError {
             socketFactory.hookEvent = function(name, callback) {
                 assert(name == "ERROR");
             };
-            socketFactory.onError(()=>{});
+            socketFactory.onSocketFactoryError(()=>{});
         });
     }
 }
@@ -2202,7 +2234,7 @@ export class SocketFactoryOnClose {
 }
 
 @TestSuite()
-export class SocketFactoryOnRefusedClientConnection {
+export class SocketFactoryOnRefuseClientConnection {
     @Test()
     public successful_call() {
         assert.doesNotThrow(() => {
@@ -2230,9 +2262,9 @@ export class SocketFactoryOnRefusedClientConnection {
 
             //@ts-ignore
             socketFactory.hookEvent = function(name, callback) {
-                assert(name == "CLIENT_REFUSE");
+                assert(name == "CLIENT_IP_REFUSE");
             };
-            socketFactory.onRefusedClientConnection(()=>{});
+            socketFactory.onClientIPRefuse(()=>{});
         });
     }
 }
@@ -2279,7 +2311,7 @@ export class SocketFactoryHookUnhookTriggerEvent {
             //@ts-ignore
             assert(callbackCalled == false);
             //@ts-ignore
-            socketFactory.triggerEvent("testtype", "test argument");
+            socketFactory.triggerEvent("testtype", ["test argument"]);
             //@ts-ignore
             assert(callbackCalled == true);
 

--- a/test/WSClient.spec.ts
+++ b/test/WSClient.spec.ts
@@ -253,8 +253,8 @@ export class WSClientError {
             });
             let flag = false;
             //@ts-ignore: protected method
-            client.socketError = function(buffer: Buffer) {
-                assert(buffer.toString() == "test error");
+            client.socketError = function(msg: string) {
+                assert(msg == "test error");
                 flag = true;
             };
             assert(flag == false);
@@ -275,8 +275,8 @@ export class WSClientError {
             });
             let flag = false;
             //@ts-ignore: protected method
-            client.socketError = function(buffer: Buffer) {
-                assert(buffer.toString() == "Unknown error message");
+            client.socketError = function(msg: string) {
+                assert(msg == "WebSocket could not connect");
                 flag = true;
             };
             //@ts-ignore: ignore missing input check
@@ -295,7 +295,7 @@ export class WSClientError {
             });
             let flag = false;
             //@ts-ignore: protected method
-            client.socketError = function(buffer: Buffer) {
+            client.socketError = function(msg: string) {
                 flag = true;
             };
             //@ts-ignore: ignore missing input check


### PR DESCRIPTION
+ Add various comment annotations
+ Add unhookError to TCP and WS clients
* Fix bug: needed to unhook socket error handler post connect
* Update samples and README.md to work again
* Rename Client to ClientInterface
* Change client sendString calls to new send
* Change signatures to allow for string arguments (support to textMode)
* Rename SocketAcceptedCallback to SocketAcceptCallback
* Miscellaneous code formatting
* Update tests to reflect latest changes

Resolves https://github.com/bashlund/pocket-sockets/issues/20